### PR TITLE
Add other lifecycle hooks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,10 +7,18 @@ import {
 } from 'vuex'
 
 interface ViewModelConfig {
-  loader?: object;
-  snackbar?: object;
-  lk?: object;
   validators?: object;
+}
+
+const addLifecycleHook = (vm: any, hookName: string, hook: Function) => {
+  if (Array.isArray(vm.$options[hookName])) {
+    vm.$options[hookName] = [
+      ...vm.$options[hookName],
+      async () => hook(vm),
+    ]
+  } else {
+    vm.$options[hookName] = [async () => hook(vm)]
+  }
 }
 
 // @ts-ignore
@@ -63,14 +71,7 @@ const convertClassViewModelToOptionsAPI = (vm, options: ViewModelConfig) => {
 
     vm.$options.validations = isDynamicValidationFn ? () => validations(newValidators)(vm) : validations(newValidators)
 
-    if (Array.isArray(vm.$options.mounted)) {
-      vm.$options.mounted = [
-        ...vm.$options.mounted,
-        async () => mounted(vm),
-      ]
-    } else {
-      vm.$options.mounted = [async () => mounted(vm)]
-    }
+    addLifecycleHook(vm, 'mounted', mounted)
 
     const res = vm.$options.data.apply(vm)
     vm.$options.data = () => ({ ...res, ...data(vm) })

--- a/index.ts
+++ b/index.ts
@@ -30,8 +30,17 @@ const convertClassViewModelToOptionsAPI = (vm, options: ViewModelConfig) => {
     vuex = {},
     validations = () => ({}),
     data = () => ({}),
+    beforeCreate = () => {},
+    created = () => {},
+    beforeMount = () => {},
     mounted = () => {},
+    beforeUpdate = () => {},
+    updated = () => {},
+    beforeDestroy = () => {},
+    destroyed= () => {},
   } = ViewModel
+
+  beforeCreate(vm)
 
   if (Object.keys(ViewModel).length) {
     const [newMethods, newComputedProps] = [methods, computed]
@@ -71,7 +80,13 @@ const convertClassViewModelToOptionsAPI = (vm, options: ViewModelConfig) => {
 
     vm.$options.validations = isDynamicValidationFn ? () => validations(newValidators)(vm) : validations(newValidators)
 
+    addLifecycleHook(vm, 'created', created)
+    addLifecycleHook(vm, 'beforeMount', beforeMount)
     addLifecycleHook(vm, 'mounted', mounted)
+    addLifecycleHook(vm, 'beforeUpdate', beforeUpdate)
+    addLifecycleHook(vm, 'updated', updated)
+    addLifecycleHook(vm, 'beforeDestroy', beforeDestroy)
+    addLifecycleHook(vm, 'destroyed', destroyed)
 
     const res = vm.$options.data.apply(vm)
     vm.$options.data = () => ({ ...res, ...data(vm) })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumkani/view-model-api",
-  "version": "1.1.0",
+  "version": "1.2.0-beta.0",
   "main": "index.js",
   "repository": "git@github.com:Lumkani/vue-view-model-api.git",
   "author": "shailen <shailen@lumkani.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumkani/view-model-api",
-  "version": "1.2.0-beta.0",
+  "version": "1.2.0-beta.1",
   "main": "index.js",
   "repository": "git@github.com:Lumkani/vue-view-model-api.git",
   "author": "shailen <shailen@lumkani.com>",


### PR DESCRIPTION
Added all native lifecycle hooks to ViewModel API

* `beforeCreate`
* `created`
* `beforeMount`
* `mounted`
* `beforeUpdate`
* `updated`
* `beforeDestroy`
* `destroyed`